### PR TITLE
feat(feature/donkey/#79): 타인 프로필 페이지 구현

### DIFF
--- a/instagram/src/components/UserPage/HeaderSection.jsx
+++ b/instagram/src/components/UserPage/HeaderSection.jsx
@@ -5,10 +5,10 @@ import {
   UserName,
 } from "../../styles/UserPage/HeaderSectionStyle";
 
-function HeaderSection({ userName, userNickname, postData }) {
+function HeaderSection({ isMyPage, userName, userNickname, postData }) {
   return (
     <HeaderContainer>
-      <IdEditGear userNickname={userNickname} />
+      <IdEditGear isMyPage={isMyPage} userNickname={userNickname} />
       <PostsFollows postData={postData} />
       <UserName>{`${userName}`}</UserName>
     </HeaderContainer>

--- a/instagram/src/components/UserPage/HeaderSection.jsx
+++ b/instagram/src/components/UserPage/HeaderSection.jsx
@@ -10,7 +10,7 @@ function HeaderSection({ isMyPage, userName, userNickname, postData }) {
     <HeaderContainer>
       <IdEditGear isMyPage={isMyPage} userNickname={userNickname} />
       <PostsFollows postData={postData} />
-      <UserName>{`${userName}`}</UserName>
+      <UserName>{userName ? `${userName}` : "이름 없음"}</UserName>
     </HeaderContainer>
   );
 }

--- a/instagram/src/components/UserPage/IdEditGear.jsx
+++ b/instagram/src/components/UserPage/IdEditGear.jsx
@@ -9,14 +9,23 @@ import {
   EditBtn,
 } from "../../styles/UserPage/IdEditGearStyle";
 
-function IdEditGear({ userNickname }) {
+function IdEditGear({ isMyPage, userNickname }) {
   return (
-    <IdEditGearBox>
-      {/* 유저네임, 프로필편집버튼, 톱니바퀴 */}
-      <Nickname>{`${userNickname}`}</Nickname>
-      <EditButton />
-      <Gear />
-    </IdEditGearBox>
+    <>
+      {isMyPage ? (
+        <IdEditGearBox>
+          {/* 유저네임, 프로필편집버튼, 톱니바퀴 */}
+          <Nickname>{`${userNickname}`}</Nickname>
+          <EditButton />
+          <Gear />
+        </IdEditGearBox>
+      ) : (
+        <IdEditGearBox>
+          {/* 유저네임, 프로필편집버튼, 톱니바퀴 */}
+          <Nickname>{`${userNickname}`}</Nickname>
+        </IdEditGearBox>
+      )}
+    </>
   );
 }
 

--- a/instagram/src/components/UserPage/ProfilePic.jsx
+++ b/instagram/src/components/UserPage/ProfilePic.jsx
@@ -8,7 +8,11 @@ function ProfilePic({ profileImg }) {
     <PictureBox>
       {/* 사진 박스 */}
       <ProfilePicture
-        src={profileImg ? profileImg : "img/defaultProfile.jpg"}
+        src={
+          profileImg && profileImg.startsWith("https://4terms3buket")
+            ? profileImg
+            : "img/defaultProfile.jpg"
+        }
       />
     </PictureBox>
   );

--- a/instagram/src/components/UserPage/ProfilePic.jsx
+++ b/instagram/src/components/UserPage/ProfilePic.jsx
@@ -7,7 +7,9 @@ function ProfilePic({ profileImg }) {
   return (
     <PictureBox>
       {/* 사진 박스 */}
-      <ProfilePicture src={profileImg} />
+      <ProfilePicture
+        src={profileImg ? profileImg : "img/defaultProfile.jpg"}
+      />
     </PictureBox>
   );
 }

--- a/instagram/src/components/UserPage/UserHeader.jsx
+++ b/instagram/src/components/UserPage/UserHeader.jsx
@@ -2,12 +2,13 @@ import ProfilePic from "./ProfilePic";
 import HeaderSection from "./HeaderSection";
 import { HeaderContainer } from "../../styles/UserPage/UserHeaderStyle";
 
-function UserHeader({ isLoaded, userInfo, postData }) {
+function UserHeader({ isMyPage, userInfo, postData }) {
   return (
     <>
       <HeaderContainer>
         <ProfilePic profileImg={userInfo.profile_image} />
         <HeaderSection
+          isMyPage={isMyPage}
           userName={userInfo.name}
           userNickname={userInfo.nickname}
           postData={postData}

--- a/instagram/src/pages/UserPage.jsx
+++ b/instagram/src/pages/UserPage.jsx
@@ -32,6 +32,46 @@ function UserPage() {
       setIsLoaded(true);
   }, [userNo, userInfo.name, userInfo.nickname]);
 
+  const OtherPage = () => {
+    const [otherNo, setOtherNo] = useState(null);
+    const [otherPost, setOtherPost] = useState({});
+    const [otherInfo, setOtherInfo] = useState({});
+    useEffect(() => {
+      (async () => {
+        const {
+          data: { user },
+        } = await axios.get(`user/search/${nickname}`);
+        setOtherNo(user[0].no);
+      })();
+    }, []);
+
+    useEffect(() => {
+      axios.get(`post/profile/41`).then((res) => setOtherPost({ ...res.data }));
+      axios
+        .get(`user/profile/${otherNo}`)
+        .then((res) => setOtherInfo({ ...res.data.userinfo }));
+    }, [otherNo]);
+
+    return (
+      <>
+        {!(otherInfo.name === undefined && otherInfo.nickname === undefined) ? (
+          <>
+            <Navigation />
+            <Container>
+              <UserHeader
+                isMyPage={isMyPage}
+                userInfo={otherInfo}
+                postData={otherPost}
+              />
+              <HeaderBaseline />
+              <UserPostings postData={otherPost} />
+            </Container>
+          </>
+        ) : null}
+      </>
+    );
+  };
+
   return (
     <>
       {isLoaded ? (
@@ -40,8 +80,8 @@ function UserPage() {
             <Navigation />
             <Container>
               <UserHeader
+                isMyPage={isMyPage}
                 userInfo={userInfo}
-                isLoaded={isLoaded}
                 postData={postData}
               />
               <HeaderBaseline />
@@ -49,7 +89,7 @@ function UserPage() {
             </Container>
           </>
         ) : (
-          <div>{`${nickname}`}의 페이지다</div>
+          <OtherPage />
         )
       ) : null}
     </>


### PR DESCRIPTION
url에 userNo가 보이는건 좀 아닌 것 같아서 유저페이지 url path를 닉네임으로 하게 됨 
닉네임으로는 해당 유저의 정보나 게시물 데이터를 요청할 수가 없음
그래서 유저 검색 요청을 이용해서 해당 유저의 userNo를 조회하고 해당 유저페이지에 나타낼 정보를 받아옴 